### PR TITLE
Handle missing web request keys in server endpoints

### DIFF
--- a/ServerLibrary/Envir/WebServer.cs
+++ b/ServerLibrary/Envir/WebServer.cs
@@ -246,7 +246,12 @@ namespace Server.Envir
         {
             string key = context.Request.QueryString[ActivationKey];
 
-            if (string.IsNullOrEmpty(key)) return;
+            if (string.IsNullOrEmpty(key))
+            {
+                context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
+                context.Response.Close();
+                return;
+            }
 
             AccountInfo account = null;
             for (int i = 0; i < SEnvir.AccountInfoList.Count; i++)
@@ -272,7 +277,12 @@ namespace Server.Envir
         {
             string key = context.Request.QueryString[ResetKey];
 
-            if (string.IsNullOrEmpty(key)) return;
+            if (string.IsNullOrEmpty(key))
+            {
+                context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
+                context.Response.Close();
+                return;
+            }
 
             AccountInfo account = null;
             for (int i = 0; i < SEnvir.AccountInfoList.Count; i++)
@@ -297,6 +307,13 @@ namespace Server.Envir
         private static void DeleteAccount(HttpListenerContext context)
         {
             string key = context.Request.QueryString[DeleteKey];
+
+            if (string.IsNullOrEmpty(key))
+            {
+                context.Response.StatusCode = (int)HttpStatusCode.BadRequest;
+                context.Response.Close();
+                return;
+            }
 
             AccountInfo account = null;
             for (int i = 0; i < SEnvir.AccountInfoList.Count; i++)


### PR DESCRIPTION
## Summary
- return an HTTP 400 response when web server requests omit required keys
- ensure activation, reset, and delete endpoints always close the response stream

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f0095f593c832da3e8a36097f8a082