### PR TITLE
Dispose remaining client dialogs and controls

### DIFF
--- a/Client/Controls/DXConfigWindow.cs
+++ b/Client/Controls/DXConfigWindow.cs
@@ -1545,6 +1545,14 @@ namespace Client.Controls
                     ColourTab = null;
                 }
 
+                if (ResetColoursButton != null)
+                {
+                    if (!ResetColoursButton.IsDisposed)
+                        ResetColoursButton.Dispose();
+
+                    ResetColoursButton = null;
+                }
+
                 if (LocalForeColourBox != null)
                 {
                     if (!LocalForeColourBox.IsDisposed)

--- a/Client/Scenes/Views/BundleDialog.cs
+++ b/Client/Scenes/Views/BundleDialog.cs
@@ -264,6 +264,12 @@ namespace Client.Scenes.Views
 
                     ConfirmButton = null;
                 }
+
+                if (SelectedBundle != null)
+                {
+                    SelectedBundle.Locked = false;
+                    SelectedBundle = null;
+                }
             }
         }
 

--- a/Client/Scenes/Views/CaptionDialog.cs
+++ b/Client/Scenes/Views/CaptionDialog.cs
@@ -151,6 +151,14 @@ namespace Client.Scenes.Views
 
                     CaptionText = null;
                 }
+
+                if (ClientPanel != null)
+                {
+                    if (!ClientPanel.IsDisposed)
+                        ClientPanel.Dispose();
+
+                    ClientPanel = null;
+                }
             }
 
         }

--- a/Client/Scenes/Views/CompanionDialog.cs
+++ b/Client/Scenes/Views/CompanionDialog.cs
@@ -1092,6 +1092,22 @@ namespace Client.Scenes.Views
                 CompanionDisplay = null;
                 CompanionDisplayPoint = Point.Empty;
 
+                if (TabControl != null)
+                {
+                    if (!TabControl.IsDisposed)
+                        TabControl.Dispose();
+
+                    TabControl = null;
+                }
+
+                if (CompanionTab != null)
+                {
+                    if (!CompanionTab.IsDisposed)
+                        CompanionTab.Dispose();
+
+                    CompanionTab = null;
+                }
+
                 if (CloseButton != null)
                 {
                     if (!CloseButton.IsDisposed)

--- a/Client/Scenes/Views/DungeonFinderDialog.cs
+++ b/Client/Scenes/Views/DungeonFinderDialog.cs
@@ -437,7 +437,89 @@ namespace Client.Scenes.Views
 
             if (disposing)
             {
+                SelectedDungeonRowChanged = null;
 
+                if (TabControl != null)
+                {
+                    if (!TabControl.IsDisposed)
+                        TabControl.Dispose();
+
+                    TabControl = null;
+                }
+
+                if (DungeonTab != null)
+                {
+                    if (!DungeonTab.IsDisposed)
+                        DungeonTab.Dispose();
+
+                    DungeonTab = null;
+                }
+
+                if (RaidTab != null)
+                {
+                    if (!RaidTab.IsDisposed)
+                        RaidTab.Dispose();
+
+                    RaidTab = null;
+                }
+
+                if (DungeonNameBox != null)
+                {
+                    if (!DungeonNameBox.IsDisposed)
+                        DungeonNameBox.Dispose();
+
+                    DungeonNameBox = null;
+                }
+
+                if (SortBox != null)
+                {
+                    if (!SortBox.IsDisposed)
+                        SortBox.Dispose();
+
+                    SortBox = null;
+                }
+
+                if (SearchButton != null)
+                {
+                    if (!SearchButton.IsDisposed)
+                        SearchButton.Dispose();
+
+                    SearchButton = null;
+                }
+
+                if (DungeonScrollBar != null)
+                {
+                    if (!DungeonScrollBar.IsDisposed)
+                        DungeonScrollBar.Dispose();
+
+                    DungeonScrollBar = null;
+                }
+
+                if (DungeonRows != null)
+                {
+                    for (int i = 0; i < DungeonRows.Length; i++)
+                    {
+                        if (DungeonRows[i] == null) continue;
+
+                        if (!DungeonRows[i].IsDisposed)
+                            DungeonRows[i].Dispose();
+
+                        DungeonRows[i] = null;
+                    }
+
+                    DungeonRows = null;
+                }
+
+                DungeonSearchResults?.Clear();
+                DungeonSearchResults = null;
+
+                if (JoinButton != null)
+                {
+                    if (!JoinButton.IsDisposed)
+                        JoinButton.Dispose();
+
+                    JoinButton = null;
+                }
             }
         }
 

--- a/Client/Scenes/Views/ExitDialog.cs
+++ b/Client/Scenes/Views/ExitDialog.cs
@@ -128,6 +128,14 @@ namespace Client.Scenes.Views
 
                     ExitButton = null;
                 }
+
+                if (CloseButton != null)
+                {
+                    if (!CloseButton.IsDisposed)
+                        CloseButton.Dispose();
+
+                    CloseButton = null;
+                }
             }
 
         }

--- a/Client/Scenes/Views/FilterDropDialog.cs
+++ b/Client/Scenes/Views/FilterDropDialog.cs
@@ -73,5 +73,28 @@ namespace Client.Scenes.Views
             }
         }
 
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (!disposing) return;
+
+            if (DropFiltersMap != null)
+            {
+                foreach (KeyValuePair<int, DXTextBox> pair in DropFiltersMap)
+                {
+                    DXTextBox textBox = pair.Value;
+
+                    if (textBox == null) continue;
+                    if (textBox.IsDisposed) continue;
+
+                    textBox.Dispose();
+                }
+
+                DropFiltersMap.Clear();
+                DropFiltersMap = null;
+            }
+        }
+
     }
 }

--- a/Client/Scenes/Views/FortuneCheckerDialog.cs
+++ b/Client/Scenes/Views/FortuneCheckerDialog.cs
@@ -200,6 +200,67 @@ namespace Client.Scenes.Views
             }
 
         }
+        #region IDisposable
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (disposing)
+            {
+                if (ItemNameBox != null)
+                {
+                    if (!ItemNameBox.IsDisposed)
+                        ItemNameBox.Dispose();
+
+                    ItemNameBox = null;
+                }
+
+                if (ItemTypeBox != null)
+                {
+                    if (!ItemTypeBox.IsDisposed)
+                        ItemTypeBox.Dispose();
+
+                    ItemTypeBox = null;
+                }
+
+                if (SearchScrollBar != null)
+                {
+                    if (!SearchScrollBar.IsDisposed)
+                        SearchScrollBar.Dispose();
+
+                    SearchScrollBar = null;
+                }
+
+                if (SearchButton != null)
+                {
+                    if (!SearchButton.IsDisposed)
+                        SearchButton.Dispose();
+
+                    SearchButton = null;
+                }
+
+                if (SearchRows != null)
+                {
+                    for (int i = 0; i < SearchRows.Length; i++)
+                    {
+                        if (SearchRows[i] == null) continue;
+
+                        if (!SearchRows[i].IsDisposed)
+                            SearchRows[i].Dispose();
+
+                        SearchRows[i] = null;
+                    }
+
+                    SearchRows = null;
+                }
+
+                SearchResults?.Clear();
+                SearchResults = null;
+            }
+        }
+
+        #endregion
         private void SearchScrollBar_ValueChanged(object sender, EventArgs e)
         {
             RefreshList();
@@ -486,6 +547,14 @@ namespace Client.Scenes.Views
                         ProgressLabel.Dispose();
 
                     ProgressLabel = null;
+                }
+
+                if (CheckButton != null)
+                {
+                    if (!CheckButton.IsDisposed)
+                        CheckButton.Dispose();
+
+                    CheckButton = null;
                 }
 
             }

--- a/Client/Scenes/Views/GroupDialog.cs
+++ b/Client/Scenes/Views/GroupDialog.cs
@@ -550,5 +550,44 @@ namespace Client.Scenes.Views
                 index++;
             }
         }
+
+        #region IDisposable
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (!disposing) return;
+
+            if (Labels != null)
+            {
+                foreach (DXLabel label in Labels)
+                {
+                    if (label == null) continue;
+                    if (label.IsDisposed) continue;
+
+                    label.Dispose();
+                }
+
+                Labels.Clear();
+                Labels = null;
+            }
+
+            if (HealthBars != null)
+            {
+                foreach (DXControl healthBar in HealthBars)
+                {
+                    if (healthBar == null) continue;
+                    if (healthBar.IsDisposed) continue;
+
+                    healthBar.Dispose();
+                }
+
+                HealthBars.Clear();
+                HealthBars = null;
+            }
+        }
+
+        #endregion
     }
 }

--- a/Client/Scenes/Views/GuildDialog.cs
+++ b/Client/Scenes/Views/GuildDialog.cs
@@ -1958,6 +1958,14 @@ namespace Client.Scenes.Views
                     CreateTab = null;
                 }
 
+                if (CreatePanel != null)
+                {
+                    if (!CreatePanel.IsDisposed)
+                        CreatePanel.Dispose();
+
+                    CreatePanel = null;
+                }
+
                 if (TreasuryPanel != null)
                 {
                     if (!TreasuryPanel.IsDisposed)
@@ -2299,6 +2307,22 @@ namespace Client.Scenes.Views
                     WarTab = null;
                 }
 
+                if (WarPanel != null)
+                {
+                    if (!WarPanel.IsDisposed)
+                        WarPanel.Dispose();
+
+                    WarPanel = null;
+                }
+
+                if (StartWarButton != null)
+                {
+                    if (!StartWarButton.IsDisposed)
+                        StartWarButton.Dispose();
+
+                    StartWarButton = null;
+                }
+
                 #endregion
 
                 #region StyleTab
@@ -2385,6 +2409,14 @@ namespace Client.Scenes.Views
                         CastleTab.Dispose();
 
                     CastleTab = null;
+                }
+
+                if (CastlePanel != null)
+                {
+                    if (!CastlePanel.IsDisposed)
+                        CastlePanel.Dispose();
+
+                    CastlePanel = null;
                 }
 
                 if (ToggleGates != null)
@@ -3200,5 +3232,60 @@ namespace Client.Scenes.Views
             else
                 CastleDateLabel.Text = Functions.ToString(Castle.WarDate - CEnvir.Now, true);
         }
+
+        #region IDisposable
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (disposing)
+            {
+                CastleChanged = null;
+                _Castle = null;
+
+                if (CastleNameLabel != null)
+                {
+                    if (!CastleNameLabel.IsDisposed)
+                        CastleNameLabel.Dispose();
+
+                    CastleNameLabel = null;
+                }
+
+                if (CastleOwnerLabel != null)
+                {
+                    if (!CastleOwnerLabel.IsDisposed)
+                        CastleOwnerLabel.Dispose();
+
+                    CastleOwnerLabel = null;
+                }
+
+                if (CastleDateLabel != null)
+                {
+                    if (!CastleDateLabel.IsDisposed)
+                        CastleDateLabel.Dispose();
+
+                    CastleDateLabel = null;
+                }
+
+                if (ItemLabel != null)
+                {
+                    if (!ItemLabel.IsDisposed)
+                        ItemLabel.Dispose();
+
+                    ItemLabel = null;
+                }
+
+                if (RequestButton != null)
+                {
+                    if (!RequestButton.IsDisposed)
+                        RequestButton.Dispose();
+
+                    RequestButton = null;
+                }
+            }
+        }
+
+        #endregion
     }
 }

--- a/Client/Scenes/Views/InventoryDialog.cs
+++ b/Client/Scenes/Views/InventoryDialog.cs
@@ -702,6 +702,14 @@ namespace Client.Scenes.Views
                     TrashButton = null;
                 }
 
+                if (SellButton != null)
+                {
+                    if (!SellButton.IsDisposed)
+                        SellButton.Dispose();
+
+                    SellButton = null;
+                }
+
                 if (PrimaryCurrencyTitle != null)
                 {
                     if (!PrimaryCurrencyTitle.IsDisposed)

--- a/Client/Scenes/Views/LootBoxDialog.cs
+++ b/Client/Scenes/Views/LootBoxDialog.cs
@@ -413,6 +413,12 @@ namespace Client.Scenes.Views
 
                     ConfirmChoiceButton = null;
                 }
+
+                if (SelectedLootBox != null)
+                {
+                    SelectedLootBox.Locked = false;
+                    SelectedLootBox = null;
+                }
             }
         }
 

--- a/Client/Scenes/Views/MagicBarDialog.cs
+++ b/Client/Scenes/Views/MagicBarDialog.cs
@@ -388,5 +388,86 @@ namespace Client.Scenes.Views
 
             return index;
         }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (!disposing) return;
+
+            SpellSetChanged = null;
+
+            if (UpButton != null)
+            {
+                if (!UpButton.IsDisposed)
+                    UpButton.Dispose();
+
+                UpButton = null;
+            }
+
+            if (DownButton != null)
+            {
+                if (!DownButton.IsDisposed)
+                    DownButton.Dispose();
+
+                DownButton = null;
+            }
+
+            if (SetLabel != null)
+            {
+                if (!SetLabel.IsDisposed)
+                    SetLabel.Dispose();
+
+                SetLabel = null;
+            }
+
+            if (IconBorders != null)
+            {
+                foreach (KeyValuePair<SpellKey, DXImageControl> pair in IconBorders)
+                {
+                    DXImageControl control = pair.Value;
+
+                    if (control == null) continue;
+                    if (control.IsDisposed) continue;
+
+                    control.Dispose();
+                }
+
+                IconBorders.Clear();
+                IconBorders = null;
+            }
+
+            if (Icons != null)
+            {
+                foreach (KeyValuePair<SpellKey, DXImageControl> pair in Icons)
+                {
+                    DXImageControl control = pair.Value;
+
+                    if (control == null) continue;
+                    if (control.IsDisposed) continue;
+
+                    control.Dispose();
+                }
+
+                Icons.Clear();
+                Icons = null;
+            }
+
+            if (Cooldowns != null)
+            {
+                foreach (KeyValuePair<SpellKey, DXLabel> pair in Cooldowns)
+                {
+                    DXLabel label = pair.Value;
+
+                    if (label == null) continue;
+                    if (label.IsDisposed) continue;
+
+                    label.Dispose();
+                }
+
+                Cooldowns.Clear();
+                Cooldowns = null;
+            }
+        }
     }
 }

--- a/Client/Scenes/Views/MarketPlaceDialog.cs
+++ b/Client/Scenes/Views/MarketPlaceDialog.cs
@@ -2028,6 +2028,14 @@ namespace Client.Scenes.Views
                     StoreBuyPriceBox = null;
                 }
 
+                if (StoreBuyPriceLabel != null)
+                {
+                    if (!StoreBuyPriceLabel.IsDisposed)
+                        StoreBuyPriceLabel.Dispose();
+
+                    StoreBuyPriceLabel = null;
+                }
+
                 if (GameGoldBox != null)
                 {
                     if (!GameGoldBox.IsDisposed)

--- a/Client/Scenes/Views/NPCDialog.cs
+++ b/Client/Scenes/Views/NPCDialog.cs
@@ -640,6 +640,12 @@ namespace Client.Scenes.Views
             {
                 Page = null;
 
+                if (PageTextContainer != null)
+                {
+                    if (!PageTextContainer.IsDisposed)
+                        PageTextContainer.Dispose();
+                }
+
                 if (PageText != null)
                 {
                     if (!PageText.IsDisposed)
@@ -7286,6 +7292,108 @@ namespace Client.Scenes.Views
             };
         }
 
+        #region IDisposable
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (!disposing) return;
+
+            _RequiredClass = RequiredClass.None;
+            RequiredClassChanged = null;
+
+            if (ClassComboBox != null)
+            {
+                if (!ClassComboBox.IsDisposed)
+                    ClassComboBox.Dispose();
+
+                ClassComboBox = null;
+            }
+
+            if (PreviewImageBox != null)
+            {
+                if (!PreviewImageBox.IsDisposed)
+                    PreviewImageBox.Dispose();
+
+                PreviewImageBox = null;
+            }
+
+            if (TemplateCell != null)
+            {
+                if (!TemplateCell.IsDisposed)
+                    TemplateCell.Dispose();
+
+                TemplateCell = null;
+            }
+
+            if (YellowCell != null)
+            {
+                if (!YellowCell.IsDisposed)
+                    YellowCell.Dispose();
+
+                YellowCell = null;
+            }
+
+            if (BlueCell != null)
+            {
+                if (!BlueCell.IsDisposed)
+                    BlueCell.Dispose();
+
+                BlueCell = null;
+            }
+
+            if (RedCell != null)
+            {
+                if (!RedCell.IsDisposed)
+                    RedCell.Dispose();
+
+                RedCell = null;
+            }
+
+            if (PurpleCell != null)
+            {
+                if (!PurpleCell.IsDisposed)
+                    PurpleCell.Dispose();
+
+                PurpleCell = null;
+            }
+
+            if (GreenCell != null)
+            {
+                if (!GreenCell.IsDisposed)
+                    GreenCell.Dispose();
+
+                GreenCell = null;
+            }
+
+            if (GreyCell != null)
+            {
+                if (!GreyCell.IsDisposed)
+                    GreyCell.Dispose();
+
+                GreyCell = null;
+            }
+
+            if (ClassLabel != null)
+            {
+                if (!ClassLabel.IsDisposed)
+                    ClassLabel.Dispose();
+
+                ClassLabel = null;
+            }
+
+            if (AttemptButton != null)
+            {
+                if (!AttemptButton.IsDisposed)
+                    AttemptButton.Dispose();
+
+                AttemptButton = null;
+            }
+        }
+
+        #endregion
+
     }
 
     public sealed class NPCAccessoryRefineDialog : DXWindow
@@ -8077,5 +8185,23 @@ namespace Client.Scenes.Views
 
             CEnvir.Enqueue(new C.NPCRollResult());
         }
+
+        #region IDisposable
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (disposing)
+            {
+                if (_animation != null && !_animation.IsDisposed)
+                    _animation.Dispose();
+
+                if (_image != null && !_image.IsDisposed)
+                    _image.Dispose();
+            }
+        }
+
+        #endregion
     }
 }

--- a/Client/Scenes/Views/StorageDialog.cs
+++ b/Client/Scenes/Views/StorageDialog.cs
@@ -490,6 +490,14 @@ namespace Client.Scenes.Views
                     ItemNameTextBox = null;
                 }
 
+                if (ItemTypeComboBox != null)
+                {
+                    if (!ItemTypeComboBox.IsDisposed)
+                        ItemTypeComboBox.Dispose();
+
+                    ItemTypeComboBox = null;
+                }
+
                 if (CloseButton != null)
                 {
                     if (!CloseButton.IsDisposed)

--- a/Client/Scenes/Views/TimerDialog.cs
+++ b/Client/Scenes/Views/TimerDialog.cs
@@ -229,6 +229,36 @@ namespace Client.Scenes.Views
 
             _eggTimer.Loop = true;
         }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            if (!disposing) return;
+
+            _timerStarted = false;
+            _timerCounter = 0;
+            CurrentTimer = null;
+            ActiveTimers.Clear();
+
+            if (_eggTimer != null && !_eggTimer.IsDisposed)
+                _eggTimer.Dispose();
+
+            if (_1000 != null && !_1000.IsDisposed)
+                _1000.Dispose();
+
+            if (_100 != null && !_100.IsDisposed)
+                _100.Dispose();
+
+            if (_10 != null && !_10.IsDisposed)
+                _10.Dispose();
+
+            if (_1 != null && !_1.IsDisposed)
+                _1.Dispose();
+
+            if (_colon != null && !_colon.IsDisposed)
+                _colon.Dispose();
+        }
     }
 
     public class ClientTimer


### PR DESCRIPTION
## Summary
- ensure DXConfigWindow and related dialogs dispose their extra buttons and combos when torn down
- release stored selections and panels across bundle, companion, dungeon finder, guild, storage, and marketplace dialogs to avoid lingering UI references
- dispose the fortune checker row button and NPC roll animation controls so their resources are freed correctly

## Testing
- not run (dotnet not installed)


------
https://chatgpt.com/codex/tasks/task_e_68f671af443c832d8a034e0e0f4eb643