### PR TITLE
Add DX9 renderer core abstraction

### DIFF
--- a/Client/Envir/CEnvir.cs
+++ b/Client/Envir/CEnvir.cs
@@ -302,16 +302,16 @@ namespace Client.Envir
                     return;
                 }
 
-                DXManager.Device.Clear(ClearFlags.Target, Color.Black, 1, 0);
-                DXManager.Device.BeginScene();
+                DXManager.Clear(ClearFlags.Target, Color.Black, 1, 0);
+                DXManager.BeginFrame();
                 DXManager.Sprite.Begin(SpriteFlags.AlphaBlend);
 
                 DXControl.ActiveScene?.Draw();
 
                 DXManager.Sprite.End();
-                DXManager.Device.EndScene();
+                DXManager.EndFrame();
 
-                DXManager.Device.Present();
+                DXManager.Present();
                 FPSCounter++;
             }
             catch (Direct3D9Exception)

--- a/Client/Rendering/DX9RendererCore.cs
+++ b/Client/Rendering/DX9RendererCore.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using SlimDX;
+using SlimDX.Direct3D9;
+
+namespace Client.Rendering
+{
+    /// <summary>
+    /// SlimDX Direct3D9 implementation of <see cref="IRendererCore"/>.
+    /// </summary>
+    public sealed class DX9RendererCore : IRendererCore
+    {
+        private Direct3D _direct3D;
+
+        public Device Device { get; private set; }
+
+        public void InitializeDevice(PresentParameters parameters, IntPtr windowHandle)
+        {
+            DisposeDevice();
+
+            _direct3D = new Direct3D();
+            Device = new Device(
+                _direct3D,
+                _direct3D.Adapters.DefaultAdapter.Adapter,
+                DeviceType.Hardware,
+                windowHandle,
+                CreateFlags.HardwareVertexProcessing,
+                parameters);
+        }
+
+        public void ResetDevice(PresentParameters parameters)
+        {
+            Device?.Reset(parameters);
+        }
+
+        public Result TestCooperativeLevel()
+        {
+            return Device?.TestCooperativeLevel() ?? Result.Success;
+        }
+
+        public void BeginFrame()
+        {
+            Device?.BeginScene();
+        }
+
+        public void EndFrame()
+        {
+            Device?.EndScene();
+        }
+
+        public void Present()
+        {
+            Device?.Present();
+        }
+
+        public Sprite CreateSprite()
+        {
+            return Device == null ? null : new Sprite(Device);
+        }
+
+        public Line CreateLine()
+        {
+            return Device == null ? null : new Line(Device);
+        }
+
+        public Surface GetBackBuffer(int swapChain, int backBuffer)
+        {
+            return Device?.GetBackBuffer(swapChain, backBuffer);
+        }
+
+        public Texture CreateTexture(int width, int height, int levels, Usage usage, Format format, Pool pool)
+        {
+            return Device == null ? null : new Texture(Device, width, height, levels, usage, format, pool);
+        }
+
+        public Texture CreateRenderTarget(int width, int height, Format format)
+        {
+            return Device == null ? null : new Texture(Device, width, height, 1, Usage.RenderTarget, format, Pool.Default);
+        }
+
+        public IEnumerable<DisplayMode> GetDisplayModes(Format format)
+        {
+            if (_direct3D == null)
+                yield break;
+
+            AdapterInformation adapterInfo = _direct3D.Adapters.DefaultAdapter;
+
+            foreach (DisplayMode mode in adapterInfo.GetDisplayModes(format))
+                yield return mode;
+        }
+
+        public void Clear(ClearFlags flags, Color colour, float z, int stencil)
+        {
+            Device?.Clear(flags, colour, z, stencil);
+        }
+
+        public void Dispose()
+        {
+            DisposeDevice();
+        }
+
+        private void DisposeDevice()
+        {
+            if (Device != null)
+            {
+                if (!Device.Disposed)
+                    Device.Dispose();
+
+                Device = null;
+            }
+
+            if (_direct3D != null)
+            {
+                if (!_direct3D.Disposed)
+                    _direct3D.Dispose();
+
+                _direct3D = null;
+            }
+        }
+    }
+}

--- a/Client/Rendering/IRendererCore.cs
+++ b/Client/Rendering/IRendererCore.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using SlimDX;
+using SlimDX.Direct3D9;
+
+namespace Client.Rendering
+{
+    /// <summary>
+    /// Describes the rendering device backend used by the client.
+    /// Implementations are responsible for managing the device lifecycle,
+    /// frame flow and resource creation.
+    /// </summary>
+    public interface IRendererCore : IDisposable
+    {
+        Device Device { get; }
+
+        void InitializeDevice(PresentParameters parameters, IntPtr windowHandle);
+
+        void ResetDevice(PresentParameters parameters);
+
+        Result TestCooperativeLevel();
+
+        void BeginFrame();
+
+        void EndFrame();
+
+        void Present();
+
+        Sprite CreateSprite();
+
+        Line CreateLine();
+
+        Surface GetBackBuffer(int swapChain, int backBuffer);
+
+        Texture CreateTexture(int width, int height, int levels, Usage usage, Format format, Pool pool);
+
+        Texture CreateRenderTarget(int width, int height, Format format);
+
+        IEnumerable<DisplayMode> GetDisplayModes(Format format);
+
+        void Clear(ClearFlags flags, Color colour, float z, int stencil);
+    }
+}


### PR DESCRIPTION
## Summary
- add a renderer core interface and Direct3D9-backed implementation
- refactor DXManager to delegate device and resource management through the new abstraction
- update the main render loop to use the abstraction's frame lifecycle helpers

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68f6a824ba1c832da08756107f1a21cd