### PR TITLE
Add companion speech detail to Companion Info view

### DIFF
--- a/Library/Library.csproj
+++ b/Library/Library.csproj
@@ -68,6 +68,7 @@
     <Compile Include="SystemModels\CastleInfo.cs" />
     <Compile Include="SystemModels\EventInfo.cs" />
     <Compile Include="SystemModels\CompanionInfo.cs" />
+    <Compile Include="SystemModels\CompanionSpeech.cs" />
     <Compile Include="SystemModels\CompanionLevelInfo.cs" />
     <Compile Include="SystemModels\CompanionSkillInfo.cs" />
     <Compile Include="SystemModels\DropInfo.cs" />

--- a/Library/SystemModels/CompanionInfo.cs
+++ b/Library/SystemModels/CompanionInfo.cs
@@ -53,5 +53,8 @@ namespace Library.SystemModels
             }
         }
         private bool _Available;
+
+        [Association("CompanionSpeeches", true)]
+        public DBBindingList<CompanionSpeech> CompanionSpeeches { get; set; }
     }
 }

--- a/Library/SystemModels/CompanionSpeech.cs
+++ b/Library/SystemModels/CompanionSpeech.cs
@@ -1,0 +1,38 @@
+using MirDB;
+
+namespace Library.SystemModels
+{
+    public sealed class CompanionSpeech : DBObject
+    {
+        [Association("CompanionSpeeches")]
+        public CompanionInfo Companion
+        {
+            get { return _Companion; }
+            set
+            {
+                if (_Companion == value) return;
+
+                var oldValue = _Companion;
+                _Companion = value;
+
+                OnChanged(oldValue, value, nameof(Companion));
+            }
+        }
+        private CompanionInfo _Companion;
+
+        public string Speech
+        {
+            get { return _Speech; }
+            set
+            {
+                if (_Speech == value) return;
+
+                var oldValue = _Speech;
+                _Speech = value;
+
+                OnChanged(oldValue, value, nameof(Speech));
+            }
+        }
+        private string _Speech;
+    }
+}

--- a/LibraryCore/SystemModels/CompanionInfo.cs
+++ b/LibraryCore/SystemModels/CompanionInfo.cs
@@ -49,5 +49,8 @@ namespace Library.SystemModels
             }
         }
         private bool _Available;
+
+        [Association("CompanionSpeeches", true)]
+        public DBBindingList<CompanionSpeech> CompanionSpeeches { get; set; }
     }
 }

--- a/LibraryCore/SystemModels/CompanionSpeech.cs
+++ b/LibraryCore/SystemModels/CompanionSpeech.cs
@@ -1,0 +1,38 @@
+using MirDB;
+
+namespace Library.SystemModels
+{
+    public sealed class CompanionSpeech : DBObject
+    {
+        [Association("CompanionSpeeches")]
+        public CompanionInfo Companion
+        {
+            get { return _Companion; }
+            set
+            {
+                if (_Companion == value) return;
+
+                var oldValue = _Companion;
+                _Companion = value;
+
+                OnChanged(oldValue, value, nameof(Companion));
+            }
+        }
+        private CompanionInfo _Companion;
+
+        public string Speech
+        {
+            get { return _Speech; }
+            set
+            {
+                if (_Speech == value) return;
+
+                var oldValue = _Speech;
+                _Speech = value;
+
+                OnChanged(oldValue, value, nameof(Speech));
+            }
+        }
+        private string _Speech;
+    }
+}

--- a/Server/Views/CompanionInfoView.Designer.cs
+++ b/Server/Views/CompanionInfoView.Designer.cs
@@ -28,12 +28,15 @@
         /// </summary>
         private void InitializeComponent()
         {
+            DevExpress.XtraGrid.GridLevelNode gridLevelNode1 = new DevExpress.XtraGrid.GridLevelNode();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(CompanionInfoView));
             this.ribbon = new DevExpress.XtraBars.Ribbon.RibbonControl();
             this.SaveButton = new DevExpress.XtraBars.BarButtonItem();
             this.ribbonPage1 = new DevExpress.XtraBars.Ribbon.RibbonPage();
             this.ribbonPageGroup1 = new DevExpress.XtraBars.Ribbon.RibbonPageGroup();
             this.CompanionInfoGridControl = new DevExpress.XtraGrid.GridControl();
+            this.CompanionSpeechGridView = new DevExpress.XtraGrid.Views.Grid.GridView();
+            this.gridColumn14 = new DevExpress.XtraGrid.Columns.GridColumn();
             this.CompanionInfoGridView = new DevExpress.XtraGrid.Views.Grid.GridView();
             this.gridColumn1 = new DevExpress.XtraGrid.Columns.GridColumn();
             this.MonsterInfoLookUpEdit = new DevExpress.XtraEditors.Repository.RepositoryItemLookUpEdit();
@@ -64,6 +67,7 @@
             this.ExportButton = new DevExpress.XtraBars.BarButtonItem();
             ((System.ComponentModel.ISupportInitialize)(this.ribbon)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.CompanionInfoGridControl)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.CompanionSpeechGridView)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.CompanionInfoGridView)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.MonsterInfoLookUpEdit)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.tabPane1)).BeginInit();
@@ -124,25 +128,52 @@
             // CompanionInfoGridControl
             // 
             this.CompanionInfoGridControl.Dock = System.Windows.Forms.DockStyle.Fill;
+            gridLevelNode1.LevelTemplate = this.CompanionSpeechGridView;
+            gridLevelNode1.RelationName = "CompanionSpeeches";
+            this.CompanionInfoGridControl.LevelTree.Nodes.AddRange(new DevExpress.XtraGrid.GridLevelNode[] {
+            gridLevelNode1});
             this.CompanionInfoGridControl.Location = new System.Drawing.Point(0, 0);
             this.CompanionInfoGridControl.MainView = this.CompanionInfoGridView;
             this.CompanionInfoGridControl.MenuManager = this.ribbon;
             this.CompanionInfoGridControl.Name = "CompanionInfoGridControl";
             this.CompanionInfoGridControl.RepositoryItems.AddRange(new DevExpress.XtraEditors.Repository.RepositoryItem[] {
             this.MonsterInfoLookUpEdit});
+            this.CompanionInfoGridControl.ShowOnlyPredefinedDetails = true;
             this.CompanionInfoGridControl.Size = new System.Drawing.Size(972, 371);
             this.CompanionInfoGridControl.TabIndex = 2;
             this.CompanionInfoGridControl.ViewCollection.AddRange(new DevExpress.XtraGrid.Views.Base.BaseView[] {
+            this.CompanionSpeechGridView,
             this.CompanionInfoGridView});
-            // 
+            //
+            // CompanionSpeechGridView
+            //
+            this.CompanionSpeechGridView.Columns.AddRange(new DevExpress.XtraGrid.Columns.GridColumn[] {
+            this.gridColumn14});
+            this.CompanionSpeechGridView.GridControl = this.CompanionInfoGridControl;
+            this.CompanionSpeechGridView.Name = "CompanionSpeechGridView";
+            this.CompanionSpeechGridView.OptionsView.EnableAppearanceEvenRow = true;
+            this.CompanionSpeechGridView.OptionsView.EnableAppearanceOddRow = true;
+            this.CompanionSpeechGridView.OptionsView.NewItemRowPosition = DevExpress.XtraGrid.Views.Grid.NewItemRowPosition.Top;
+            this.CompanionSpeechGridView.OptionsView.ShowButtonMode = DevExpress.XtraGrid.Views.Base.ShowButtonModeEnum.ShowAlways;
+            this.CompanionSpeechGridView.OptionsView.ShowGroupPanel = false;
+            //
+            // gridColumn14
+            //
+            this.gridColumn14.Caption = "Speech";
+            this.gridColumn14.FieldName = "Speech";
+            this.gridColumn14.Name = "gridColumn14";
+            this.gridColumn14.Visible = true;
+            this.gridColumn14.VisibleIndex = 0;
+            //
             // CompanionInfoGridView
-            // 
+            //
             this.CompanionInfoGridView.Columns.AddRange(new DevExpress.XtraGrid.Columns.GridColumn[] {
             this.gridColumn1,
             this.gridColumn3,
             this.gridColumn4});
             this.CompanionInfoGridView.GridControl = this.CompanionInfoGridControl;
             this.CompanionInfoGridView.Name = "CompanionInfoGridView";
+            this.CompanionInfoGridView.OptionsDetail.AllowExpandEmptyDetails = true;
             this.CompanionInfoGridView.OptionsView.EnableAppearanceEvenRow = true;
             this.CompanionInfoGridView.OptionsView.EnableAppearanceOddRow = true;
             this.CompanionInfoGridView.OptionsView.NewItemRowPosition = DevExpress.XtraGrid.Views.Grid.NewItemRowPosition.Top;
@@ -427,6 +458,7 @@
             this.Text = "Companion Info";
             ((System.ComponentModel.ISupportInitialize)(this.ribbon)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.CompanionInfoGridControl)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.CompanionSpeechGridView)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.CompanionInfoGridView)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.MonsterInfoLookUpEdit)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.tabPane1)).EndInit();
@@ -452,6 +484,8 @@
         private DevExpress.XtraBars.Ribbon.RibbonPageGroup ribbonPageGroup1;
         private DevExpress.XtraBars.BarButtonItem SaveButton;
         private DevExpress.XtraGrid.GridControl CompanionInfoGridControl;
+        private DevExpress.XtraGrid.Views.Grid.GridView CompanionSpeechGridView;
+        private DevExpress.XtraGrid.Columns.GridColumn gridColumn14;
         private DevExpress.XtraGrid.Views.Grid.GridView CompanionInfoGridView;
         private DevExpress.XtraGrid.Columns.GridColumn gridColumn1;
         private DevExpress.XtraGrid.Columns.GridColumn gridColumn3;

--- a/Server/Views/CompanionInfoView.cs
+++ b/Server/Views/CompanionInfoView.cs
@@ -22,6 +22,7 @@ namespace Server.Views
             base.OnLoad(e);
 
             SMain.SetUpView(CompanionInfoGridView);
+            SMain.SetUpView(CompanionSpeechGridView);
             SMain.SetUpView(CompanionLevelInfoGridView);
             SMain.SetUpView(CompanionSkillInfoGridView);
         }


### PR DESCRIPTION
## Summary
- add a CompanionSpeech child object to CompanionInfo in both runtime libraries
- include the new model in the legacy library project file
- expose companion speech entries as a master-detail grid under Companion Info records in the server view

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fb746217c0832dae4374c5ebbb478e