### PR TITLE
Reset conquest schedule after wars finish

### DIFF
--- a/Client/Envir/CConnection.cs
+++ b/Client/Envir/CConnection.cs
@@ -4073,7 +4073,11 @@ namespace Client.Envir
         }
         public void Process(S.GuildConquestFinished p)
         {
-            GameScene.Game.ConquestWars.Remove(CEnvir.CastleInfoList.Binding.First(x => x.Index == p.Index));
+            CastleInfo castle = CEnvir.CastleInfoList.Binding.First(x => x.Index == p.Index);
+
+            GameScene.Game.ConquestWars.Remove(castle);
+
+            castle.WarDate = DateTime.MinValue;
 
             foreach (MapObject ob in GameScene.Game.MapControl.Objects)
                 ob.NameChanged();


### PR DESCRIPTION
## Summary
- clear the tracked war date for a castle when a conquest finishes
- ensure clients no longer display an in-progress conquest once the battle ends

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690635322334832d88b0b5748edf0b59