### PR TITLE
Add player stats help document and update guide

### DIFF
--- a/docs/help-content-guide.md
+++ b/docs/help-content-guide.md
@@ -1,0 +1,17 @@
+# Help Content Guide
+
+Use this guide to add or update in-game help content stored as JSON documents. The existing `docs/player-stats-help.json` file is an example that follows this format, but the same structure applies to any new topics you want to document.
+
+## JSON structure
+- Each help document is an array of entries with `Title`, `Order`, and `Description`.
+- Entries contain `Pages`, each with its own `Title`, `Order`, and `Sections`.
+- Sections hold the short `Content` shown to players. Keep these concise and player-friendly.
+
+## How to add or update help content
+1. Create or open a JSON file under `docs/` (for example, `docs/<topic>-help.json`).
+2. Preserve the outer array and keys (`Title`, `Order`, `Description`, `Pages`, `Sections`, `Content`).
+3. Add or edit sections to adjust wording, ordering, or to add new topic groups.
+4. When adding new pages or sections, set `Order` values so they appear in the desired sequence.
+5. Validate that the JSON remains well-formed before importing into the game.
+
+For recurring updates, request changes by specifying the file path and the exact sections or pages to adjust.

--- a/docs/player-stats-help.json
+++ b/docs/player-stats-help.json
@@ -1,0 +1,89 @@
+[
+  {
+    "Title": "Stats",
+    "Order": 0,
+    "Description": "Quick guide to your character’s key combat numbers.",
+    "Pages": [
+      {
+        "Title": "Defense",
+        "Order": 0,
+        "Sections": [
+          {
+            "Title": "AC",
+            "Order": 0,
+            "Content": "Armor Class reduces incoming physical melee damage; higher AC means hits hurt less."
+          },
+          {
+            "Title": "MR",
+            "Order": 1,
+            "Content": "Magic Resistance lowers magic damage taken; higher MR softens spells and skills aimed at you."
+          }
+        ]
+      },
+      {
+        "Title": "Physical Attack",
+        "Order": 1,
+        "Sections": [
+          {
+            "Title": "DC",
+            "Order": 0,
+            "Content": "Physical Damage stat for weapons; raises the minimum and maximum damage of your melee attacks."
+          },
+          {
+            "Title": "Accuracy & Attack Speed",
+            "Order": 1,
+            "Content": "Accuracy helps your blows land more often, while Attack Speed shortens the time between swings."
+          }
+        ]
+      },
+      {
+        "Title": "Spell Power",
+        "Order": 2,
+        "Sections": [
+          {
+            "Title": "SP (Nature) - MC",
+            "Order": 0,
+            "Content": "Nature Spell Power boosts magic that scales with MC; increases both low and high ends of those spells."
+          },
+          {
+            "Title": "SP (Spirit) - SC",
+            "Order": 1,
+            "Content": "Spirit Spell Power boosts magic that scales with SC; raises the damage range of spirit-based spells."
+          }
+        ]
+      },
+      {
+        "Title": "Elemental",
+        "Order": 3,
+        "Sections": [
+          {
+            "Title": "Elemental Attack",
+            "Order": 0,
+            "Content": "Fire, Ice, Lightning, Wind, Holy, Dark, and Phantom attack add extra elemental damage to your strikes."
+          },
+          {
+            "Title": "Elemental Resistance",
+            "Order": 1,
+            "Content": "Matching elemental resistances reduce damage from those elements; higher values mean you endure that element better."
+          }
+        ]
+      },
+      {
+        "Title": "Vitals & Utility",
+        "Order": 4,
+        "Sections": [
+          {
+            "Title": "Health & Mana",
+            "Order": 0,
+            "Content": "Health keeps you alive; Mana fuels spells and skills. More of each means greater staying power."
+          },
+          {
+            "Title": "Comfort",
+            "Order": 1,
+            "Content": "Comfort speeds your natural regeneration ticks, helping you recover faster over time."
+          }
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## Summary
- add a ready-to-import player stats help JSON covering attack, defense, spell power, elemental, and utility stats
- replace the player-specific update guide with a general help content guide for any help material

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d92196394832daff6dd217d78a613)